### PR TITLE
Remove email from profile form state for profile name change

### DIFF
--- a/app/frontend/pages/settings/profiles/show.tsx
+++ b/app/frontend/pages/settings/profiles/show.tsx
@@ -26,7 +26,6 @@ export default function Profile() {
   const { data, setData, patch, errors, processing, recentlySuccessful } =
     useForm({
       name: auth.user.name,
-      email: auth.user.email,
     })
 
   const submit: FormEventHandler = (e) => {

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Be sure to restart your server when you modify this file.
+
+# This file contains settings for ActionController::ParamsWrapper which
+# is enabled by default.
+
+# Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
+ActiveSupport.on_load(:action_controller) do
+  wrap_parameters format: []
+end


### PR DESCRIPTION
- Remove the additional email param from show.tx
- Disable wrapping params to avoid unpermitted params warning

Fixes #16 
