### PR TITLE
Add libyaml-dev to fix builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM base AS build
 
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git node-gyp pkg-config python-is-python3 && \
+    apt-get install --no-install-recommends -y build-essential git libyaml-dev node-gyp pkg-config python-is-python3 && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install JavaScript dependencies

--- a/Dockerfile-ssr
+++ b/Dockerfile-ssr
@@ -37,7 +37,7 @@ FROM base AS build
 
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git node-gyp pkg-config python-is-python3 && \
+    apt-get install --no-install-recommends -y build-essential git libyaml-dev node-gyp pkg-config python-is-python3 && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems


### PR DESCRIPTION
This pull request updates the dependencies in the Docker build files to include `libyaml-dev`, which is necessary for handling YAML files. The changes ensure that both the main build and SSR build environments have the required library installed.

Dependency updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L33-R33): Added `libyaml-dev` to the list of installed packages in the `FROM base AS build` section to support YAML file processing.
* [`Dockerfile-ssr`](diffhunk://#diff-5d8cb159fddd4a65b37c6f5f661a8a249e9a76cad561f26a2eed72bb8ec5102aL40-R40): Added `libyaml-dev` to the list of installed packages in the `FROM base AS build` section for SSR builds to match the main build environment.