### PR TITLE
Update .gitignore with *.DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # belong in git's global ignore instead:
 # `$XDG_CONFIG_HOME/git/ignore` or `~/.config/git/ignore`
 
+# Ignore all .DS_Store files
+*.DS_Store
+
 # Ignore bundler config.
 /.bundle
 


### PR DESCRIPTION
Added *.DS_Store to .gitignore.  

Working in a fork on mac and every commit without the ignore creates a .DS_Store file that need not be present.