### PR TITLE
Adopt omakase Ruby formatting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,29 +1,8 @@
 # Omakase Ruby styling for Rails
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
-Layout/SpaceInsideArrayLiteralBrackets:
-  EnforcedStyle: no_space
-
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: true
-  EnforcedStyle: no_space
-
-Layout/IndentationConsistency:
-  Enabled: true
-  EnforcedStyle: normal
-
-Layout/IndentationWidth:
-  Enabled: true
-  Width: 2
-
-Layout/EmptyLinesAroundAccessModifier:
-  Enabled: true
-
-Style/FrozenStringLiteralComment:
-  Enabled: true
-
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: double_quotes
-  Include:
-    - "**/*"
+# Overwrite or add rules to create your own house style
+#
+# # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
+# Layout/SpaceInsideArrayLiteralBrackets:
+#   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "solid_cable"
 gem "bootsnap", require: false
 
 # Deploy this application anywhere as a Docker container [https://kamal-deploy.org]
-gem "kamal", require: false, group: [:development, :deploy]
+gem "kamal", require: false, group: [ :development, :deploy ]
 
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
 gem "thruster", require: false

--- a/app/controllers/identity/password_resets_controller.rb
+++ b/app/controllers/identity/password_resets_controller.rb
@@ -9,7 +9,7 @@ class Identity::PasswordResetsController < InertiaController
   end
 
   def edit
-    render inertia: {email: @user.email, sid: params[:sid]}
+    render inertia: { email: @user.email, sid: params[:sid] }
   end
 
   def create
@@ -25,7 +25,7 @@ class Identity::PasswordResetsController < InertiaController
     if @user.update(user_params)
       redirect_to sign_in_path, notice: "Your password was reset successfully. Please sign in"
     else
-      redirect_to edit_identity_password_reset_path(sid: params[:sid]), inertia: {errors: @user.errors}
+      redirect_to edit_identity_password_reset_path(sid: params[:sid]), inertia: { errors: @user.errors }
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < InertiaController
   def create
     if user = User.authenticate_by(email: params[:email], password: params[:password])
       @session = user.sessions.create!
-      cookies.signed.permanent[:session_token] = {value: @session.id, httponly: true}
+      cookies.signed.permanent[:session_token] = { value: @session.id, httponly: true }
 
       redirect_to dashboard_path, notice: "Signed in successfully"
     else
@@ -22,7 +22,7 @@ class SessionsController < InertiaController
   def destroy
     @session.destroy!
     Current.session = nil
-    redirect_to settings_sessions_path, notice: "That session has been logged out", inertia: {clear_history: true}
+    redirect_to settings_sessions_path, notice: "That session has been logged out", inertia: { clear_history: true }
   end
 
   private

--- a/app/controllers/settings/emails_controller.rb
+++ b/app/controllers/settings/emails_controller.rb
@@ -10,7 +10,7 @@ class Settings::EmailsController < InertiaController
     if @user.update(user_params)
       redirect_to_success
     else
-      redirect_to settings_email_path, inertia: {errors: @user.errors}
+      redirect_to settings_email_path, inertia: { errors: @user.errors }
     end
   end
 

--- a/app/controllers/settings/passwords_controller.rb
+++ b/app/controllers/settings/passwords_controller.rb
@@ -10,7 +10,7 @@ class Settings::PasswordsController < InertiaController
     if @user.update(user_params)
       redirect_to settings_password_path, notice: "Your password has been changed"
     else
-      redirect_to settings_password_path, inertia: {errors: @user.errors}
+      redirect_to settings_password_path, inertia: { errors: @user.errors }
     end
   end
 

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -10,7 +10,7 @@ class Settings::ProfilesController < InertiaController
     if @user.update(user_params)
       redirect_to settings_profile_path, notice: "Your profile has been updated"
     else
-      redirect_to settings_profile_path, inertia: {errors: @user.errors}
+      redirect_to settings_profile_path, inertia: { errors: @user.errors }
     end
   end
 

--- a/app/controllers/settings/sessions_controller.rb
+++ b/app/controllers/settings/sessions_controller.rb
@@ -4,6 +4,6 @@ class Settings::SessionsController < InertiaController
   def index
     sessions = Current.user.sessions.order(created_at: :desc)
 
-    render inertia: {sessions: sessions.as_json(only: %i[id user_agent ip_address created_at])}
+    render inertia: { sessions: sessions.as_json(only: %i[id user_agent ip_address created_at]) }
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,12 +13,12 @@ class UsersController < InertiaController
 
     if @user.save
       session_record = @user.sessions.create!
-      cookies.signed.permanent[:session_token] = {value: session_record.id, httponly: true}
+      cookies.signed.permanent[:session_token] = { value: session_record.id, httponly: true }
 
       send_email_verification
       redirect_to dashboard_path, notice: "Welcome! You have signed up successfully"
     else
-      redirect_to sign_up_path, inertia: {errors: @user.errors}
+      redirect_to sign_up_path, inertia: { errors: @user.errors }
     end
   end
 
@@ -27,9 +27,9 @@ class UsersController < InertiaController
     if user.authenticate(params[:password_challenge] || "")
       user.destroy!
       Current.session = nil
-      redirect_to root_path, notice: "Your account has been deleted", inertia: {clear_history: true}
+      redirect_to root_path, notice: "Your account has been deleted", inertia: { clear_history: true }
     else
-      redirect_to settings_profile_path, inertia: {errors: {password_challenge: "Password challenge is invalid"}}
+      redirect_to settings_profile_path, inertia: { errors: { password_challenge: "Password challenge is invalid" } }
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 module ApplicationHelper
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
   layout "mailer"

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,8 +15,8 @@ class User < ApplicationRecord
   has_many :sessions, dependent: :destroy
 
   validates :name, presence: true
-  validates :email, presence: true, uniqueness: true, format: {with: URI::MailTo::EMAIL_REGEXP}
-  validates :password, allow_nil: true, length: {minimum: 12}
+  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :password, allow_nil: true, length: { minimum: 12 }
 
   normalizes :email, with: -> { _1.strip.downcase }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "boot"
 
 require "rails"

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Run using bin/ci
 
 CI.run do

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Load the Rails application.
 require_relative "application"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
@@ -22,7 +20,7 @@ Rails.application.configure do
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
-    config.public_file_server.headers = {"cache-control" => "public, max-age=#{2.days.to_i}"}
+    config.public_file_server.headers = { "cache-control" => "public, max-age=#{2.days.to_i}" }
   else
     config.action_controller.perform_caching = false
   end
@@ -40,7 +38,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Set localhost to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = {host: "localhost", port: 3000}
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   config.action_mailer.delivery_method = :letter_opener
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
@@ -18,7 +16,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
 
   # Cache assets for far-future expiry since they are all digest stamped.
-  config.public_file_server.headers = {"cache-control" => "public, max-age=#{1.year.to_i}"}
+  config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
@@ -36,7 +34,7 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
-  config.log_tags = [:request_id]
+  config.log_tags = [ :request_id ]
   config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!).
@@ -53,14 +51,14 @@ Rails.application.configure do
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = {database: {writing: :queue}}
+  config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = {host: "example.com"}
+  config.action_mailer.default_url_options = { host: "example.com" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {
@@ -79,7 +77,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Only use :id for inspections in production.
-  config.active_record.attributes_for_inspect = [:id]
+  config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
 # your test database is "scratch space" for the test suite and is wiped
@@ -18,7 +16,7 @@ Rails.application.configure do
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with cache-control for performance.
-  config.public_file_server.headers = {"cache-control" => "public, max-age=3600"}
+  config.public_file_server.headers = { "cache-control" => "public, max-age=3600" }
 
   # Show full error reports.
   config.consider_all_requests_local = true
@@ -39,7 +37,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = {host: "example.com"}
+  config.action_mailer.default_url_options = { host: "example.com" }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy.

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Be sure to restart your server when you modify this file.
 
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/typelizer.rb
+++ b/config/initializers/typelizer.rb
@@ -3,5 +3,5 @@
 Typelizer.configure do |config|
   config.routes.enabled = true
   config.routes.output_dir = Rails.root.join("app/javascript/routes")
-  config.routes.exclude = [/^\/rails/, /^\/up/]
+  config.routes.exclude = [ /^\/rails/, /^\/up/ ]
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This configuration file will be evaluated by Puma. The top-level methods that
 # are invoked here are part of Puma's configuration DSL. For more information
 # about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,21 +6,21 @@ Rails.application.routes.draw do
   get  "sign_up", to: "users#new", as: :sign_up
   post "sign_up", to: "users#create"
 
-  resources :sessions, only: [:destroy]
-  resource :users, only: [:destroy]
+  resources :sessions, only: [ :destroy ]
+  resource :users, only: [ :destroy ]
 
   namespace :identity do
-    resource :email_verification, only: [:show, :create]
-    resource :password_reset,     only: [:new, :edit, :create, :update]
+    resource :email_verification, only: [ :show, :create ]
+    resource :password_reset,     only: [ :new, :edit, :create, :update ]
   end
 
   get :dashboard, to: "dashboard#index"
 
   namespace :settings do
-    resource :profile, only: [:show, :update]
-    resource :password, only: [:show, :update]
-    resource :email, only: [:show, :update]
-    resources :sessions, only: [:index]
+    resource :profile, only: [ :show, :update ]
+    resource :password, only: [ :show, :update ]
+    resource :email, only: [ :show, :update ]
+    resources :sessions, only: [ :index ]
     inertia :appearance
   end
 

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ActiveRecord::Schema[7.2].define(version: 1) do
   create_table "solid_cache_entries", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false

--- a/db/migrate/20250211160810_create_users.rb
+++ b/db/migrate/20250211160810_create_users.rb
@@ -4,7 +4,7 @@ class CreateUsers < ActiveRecord::Migration[8.0]
   def change
     create_table :users do |t|
       t.string :name,            null: false
-      t.string :email,           null: false, index: {unique: true}
+      t.string :email,           null: false, index: { unique: true }
       t.string :password_digest, null: false
 
       t.boolean :verified, null: false, default: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file should ensure the existence of records required to run the application in every environment (production,
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UserMailer, type: :mailer do
     let(:mail) { described_class.with(user: users(:one)).email_verification }
 
     it "sends to the user's email" do
-      expect(mail.to).to eq(["one@example.com"])
+      expect(mail.to).to eq([ "one@example.com" ])
     end
 
     it "has the correct subject" do
@@ -21,7 +21,7 @@ RSpec.describe UserMailer, type: :mailer do
     let(:mail) { described_class.with(user: users(:one)).password_reset }
 
     it "sends to the user's email" do
-      expect(mail.to).to eq(["one@example.com"])
+      expect(mail.to).to eq([ "one@example.com" ])
     end
 
     it "has the correct subject" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,13 +18,13 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 
 RSpec.configure do |config|
-  config.fixture_paths = [Rails.root.join("spec/fixtures")]
+  config.fixture_paths = [ Rails.root.join("spec/fixtures") ]
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 
   config.before(type: :system) do
-    driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+    driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
   end
 
   config.include ActiveSupport::Testing::TimeHelpers

--- a/spec/requests/identity/password_resets_spec.rb
+++ b/spec/requests/identity/password_resets_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Identity::PasswordResets", type: :request do
     context "with a verified user" do
       it "sends a password reset email" do
         expect {
-          post identity_password_reset_path, params: {email: users(:one).email}
+          post identity_password_reset_path, params: { email: users(:one).email }
         }.to have_enqueued_mail(UserMailer, :password_reset)
         expect(response).to redirect_to(sign_in_path)
       end
@@ -27,7 +27,7 @@ RSpec.describe "Identity::PasswordResets", type: :request do
         users(:one).update!(verified: false)
 
         expect {
-          post identity_password_reset_path, params: {email: users(:one).email}
+          post identity_password_reset_path, params: { email: users(:one).email }
         }.not_to have_enqueued_mail(UserMailer, :password_reset)
         expect(response).to redirect_to(new_identity_password_reset_path)
         expect(flash[:alert]).to eq("You can't reset your password until you verify your email")
@@ -37,7 +37,7 @@ RSpec.describe "Identity::PasswordResets", type: :request do
     context "with a nonexistent email" do
       it "does not send a password reset email" do
         expect {
-          post identity_password_reset_path, params: {email: "missing@example.com"}
+          post identity_password_reset_path, params: { email: "missing@example.com" }
         }.not_to have_enqueued_mail(UserMailer, :password_reset)
         expect(response).to redirect_to(new_identity_password_reset_path)
       end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Sessions", type: :request do
   describe "POST /sign_in" do
     context "with valid credentials" do
       it "signs in and sets a session cookie" do
-        post sign_in_path, params: {email: users(:one).email, password: "Secret1*3*5*"}
+        post sign_in_path, params: { email: users(:one).email, password: "Secret1*3*5*" }
         expect(response).to redirect_to(dashboard_path)
         expect(cookies[:session_token]).to be_present
       end
@@ -29,7 +29,7 @@ RSpec.describe "Sessions", type: :request do
 
     context "with invalid credentials" do
       it "redirects back with an alert" do
-        post sign_in_path, params: {email: users(:one).email, password: "wrongpassword"}
+        post sign_in_path, params: { email: users(:one).email, password: "wrongpassword" }
         expect(response).to redirect_to(sign_in_path)
         expect(flash[:alert]).to eq("That email or password is incorrect")
       end

--- a/spec/requests/settings/emails_spec.rb
+++ b/spec/requests/settings/emails_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Settings::Emails", type: :request do
           password_challenge: "wrongpassword"
         }
         expect(response).to redirect_to(settings_email_path)
-        expect(session[:inertia_errors]).to eq(password_challenge: ["is invalid"])
+        expect(session[:inertia_errors]).to eq(password_challenge: [ "is invalid" ])
         expect(users(:one).reload.email).to eq("one@example.com")
       end
     end

--- a/spec/requests/settings/passwords_spec.rb
+++ b/spec/requests/settings/passwords_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Settings::Passwords", type: :request do
           password_challenge: "wrongpassword"
         }
         expect(response).to redirect_to(settings_password_path)
-        expect(session[:inertia_errors]).to eq(password_challenge: ["is invalid"])
+        expect(session[:inertia_errors]).to eq(password_challenge: [ "is invalid" ])
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Users", type: :request do
     it "destroys current user with valid password" do
       sign_in users(:one)
       expect {
-        delete users_path, params: {password_challenge: "Secret1*3*5*"}
+        delete users_path, params: { password_challenge: "Secret1*3*5*" }
       }.to change(User, :count).by(-1)
       expect(response).to redirect_to(root_path)
     end
@@ -56,7 +56,7 @@ RSpec.describe "Users", type: :request do
     it "rejects account deletion with wrong password" do
       sign_in users(:one)
       expect {
-        delete users_path, params: {password_challenge: "wrongpassword"}
+        delete users_path, params: { password_challenge: "wrongpassword" }
       }.not_to change(User, :count)
       expect(response).to redirect_to(settings_profile_path)
     end


### PR DESCRIPTION
Drop the custom RuboCop overrides (no_space brackets/braces, forced `frozen_string_literal`) for plain rubocop-rails-omakase, and strip the `frozen_string_literal` magic comment from the Rails boilerplate files the generator also leaves uncommented.

Formatting only — `rubocop -A` made no logic changes; rubocop is clean and specs are unchanged (35 examples, 0 failures).