### PR TITLE
Add sign-in system test

### DIFF
--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Sessions", type: :system do
+  fixtures :users
+
+  it "signs in and shows the dashboard" do
+    visit sign_in_path
+
+    fill_in "Email address", with: users(:one).email
+    fill_in "Password", with: "Secret1*3*5*"
+    click_on "Log in"
+
+    expect(page).to have_current_path(dashboard_path)
+    expect(page).to have_text("Dashboard")
+  end
+end


### PR DESCRIPTION
Adds the example system test now generated by [inertia-rails/generator#18](https://github.com/inertia-rails/generator/pull/18): sign in through the browser and land on the dashboard, synced by capybara-lockstep.

The harness (lockstep gem + layout tag, `driven_by :headless_chrome`, chrome + screenshot artifacts in CI) has been fully wired here all along but never exercised — this PR's CI run is the first time it actually runs. Verified locally: passes in 4.6s, and `rails_vite` auto-builds test assets so no extra CI step is needed.