### PR TITLE
Normalize deploy.yml formatting to generated output

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -8,7 +8,6 @@ image: react_starter_kit
 servers:
   web:
     - 192.168.0.1
-
   # job:
   #   hosts:
   #     - 192.168.0.1
@@ -67,18 +66,15 @@ aliases:
   logs: app logs -f
   dbc: app exec --interactive --reuse "bin/rails dbconsole --include-password"
 
-
 # Use a persistent storage volume for sqlite database files and local Active Storage files.
 # Recommended to change this to a mounted volume path that is backed up off server.
 volumes:
   - "react_starter_kit_storage:/rails/storage"
 
-
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old
 # version inside the asset_path.
 asset_path: /rails/public
-
 
 # Configure the image builder.
 builder:


### PR DESCRIPTION
With generator [#25](https://github.com/inertia-rails/generator/pull/25)/[#26](https://github.com/inertia-rails/generator/pull/26) merged, the generator emits the Vite-aware `asset_path: /rails/public` and the registry build-cache block this repo already had. This drops the four stray blank lines so `config/deploy.yml` is byte-identical to a fresh generation. Formatting only.