### PR TITLE
Strengthen auth request specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
     jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.8)
+    json (2.20.0)
     kamal (2.11.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)

--- a/spec/requests/identity/email_verifications_spec.rb
+++ b/spec/requests/identity/email_verifications_spec.rb
@@ -43,11 +43,13 @@ RSpec.describe "Identity::EmailVerifications", type: :request do
 
   describe "POST /identity/email_verification" do
     it "resends the verification email" do
-      sign_in users(:one)
+      user = users(:one)
+      user.update!(verified: false)
+      sign_in user
 
       expect {
         post identity_email_verification_path
-      }.to have_enqueued_mail(UserMailer, :email_verification)
+      }.to have_enqueued_email(UserMailer, :email_verification).with(params: { user: user }, args: [])
       expect(response).to be_redirect
     end
   end

--- a/spec/requests/identity/password_resets_spec.rb
+++ b/spec/requests/identity/password_resets_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Identity::PasswordResets", type: :request do
       it "sends a password reset email" do
         expect {
           post identity_password_reset_path, params: { email: users(:one).email }
-        }.to have_enqueued_mail(UserMailer, :password_reset)
+        }.to have_enqueued_email(UserMailer, :password_reset).with(params: { user: users(:one) }, args: [])
         expect(response).to redirect_to(sign_in_path)
       end
     end
@@ -40,6 +40,7 @@ RSpec.describe "Identity::PasswordResets", type: :request do
           post identity_password_reset_path, params: { email: "missing@example.com" }
         }.not_to have_enqueued_mail(UserMailer, :password_reset)
         expect(response).to redirect_to(new_identity_password_reset_path)
+        expect(flash[:alert]).to eq("You can't reset your password until you verify your email")
       end
     end
   end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe "Sessions", type: :request do
         post sign_in_path, params: { email: users(:one).email, password: "Secret1*3*5*" }
         expect(response).to redirect_to(dashboard_path)
         expect(cookies[:session_token]).to be_present
+
+        get dashboard_path
+        expect(response).to have_http_status(:success)
       end
     end
 
@@ -32,6 +35,9 @@ RSpec.describe "Sessions", type: :request do
         post sign_in_path, params: { email: users(:one).email, password: "wrongpassword" }
         expect(response).to redirect_to(sign_in_path)
         expect(flash[:alert]).to eq("That email or password is incorrect")
+
+        get dashboard_path
+        expect(response).to redirect_to(sign_in_path)
       end
     end
   end
@@ -42,6 +48,7 @@ RSpec.describe "Sessions", type: :request do
       session_record = users(:one).sessions.last
       delete session_path(session_record)
       expect(response).to redirect_to(settings_sessions_path)
+      expect(Session.exists?(session_record.id)).to be(false)
     end
   end
 end


### PR DESCRIPTION
Catches react-starter-kit's auth request specs up to the generator's canonical (strengthened) versions — the last spec drift after the vue and svelte kits were converged. Backend-only; mirrors generator PR #29.

## What this does
- **sign-in**: follow-up `GET /dashboard` confirms the session is authenticated; invalid sign-in's follow-up confirms it is **not**
- **`DELETE /sessions/:id`**: asserts the session record is actually destroyed (`Session.exists?`)
- **mailers**: `have_enqueued_email(...).with(params: { user: })` — checks the right user, not just any mail
- **resend verification**: exercised as an *unverified* user
- **nonexistent-email reset**: asserts the flash copy

The 3 files are now byte-identical to the generator's canonical specs.

## Verification
- Full RSpec suite (incl. headless-chrome system test) — **36 examples, 0 failures**
- `bin/rubocop spec/` — clean (react's omakase style already matches the canonical)