### PR TITLE
Add MIT license, document generator provenance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Svyatoslav Kryukov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ for production images.
 
 ## License
 
-The project is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The project is available as open source under the terms of the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 A modern full-stack starter application with Rails backend and React frontend using Inertia.js based on the [Laravel Starter Kit](https://github.com/laravel/react-starter-kit).
 
+## About this repo
+
+This starter kit is generated output of [inertia-rails/generator](https://github.com/inertia-rails/generator):
+each generator release regenerates the app and opens an automated sync PR here, so most files in this repo
+are overwritten on every sync. **To contribute changes to the app itself, open a PR against the generator** —
+only this README and the deploy workflow are kit-owned.
+
+Prefer different options (framework, JavaScript instead of TypeScript, feature set)? Generate your own app:
+
+```sh
+rails new myapp -m https://raw.githubusercontent.com/inertia-rails/generator/dist/template.rb
+```
+
 ## Features
 
 - [Inertia Rails](https://inertia-rails.dev) & [Vite Rails](https://vite-ruby.netlify.app) setup


### PR DESCRIPTION
Two kit-owned README/meta changes: the MIT license file the README has always claimed (license section now links to it), and an "About this repo" section explaining that this kit is regenerated generator output — app changes belong in [inertia-rails/generator](https://github.com/inertia-rails/generator) PRs, since the sync overwrites everything except this README and the deploy workflow.